### PR TITLE
Remove anchor from last crumb

### DIFF
--- a/Resources/views/breadcrumbs.html.twig
+++ b/Resources/views/breadcrumbs.html.twig
@@ -1,12 +1,17 @@
 {% if breadcrumbs|length %}
-<ul class="breadcrumbs">
-    {% for crumb in breadcrumbs %}
-        {% set crumbPath = path(crumb.route, crumb.routeParameters) %}
-        {% set crumbText = crumb.label|trans(crumb.labelParameters) %}
-
-    <li{% if crumb.route == app.request.get('_route') %} class="current"{% endif %}>
-        <a href="{{ crumbPath }}" title="{{ crumbText }}">{{ crumbText }}</a>
-    </li>
-    {% endfor %}
-</ul>
+    <ul class="breadcrumbs">
+        {% for crumb in breadcrumbs %}
+            {% set crumbText = crumb.label|trans(crumb.labelParameters) %}
+            {% if crumb.route == app.request.get('_route') %}
+                <li class="current">
+                    <a title="{{ crumbText }}">{{ crumbText }}</a>
+                </li>
+            {% else %}
+                {% set crumbPath = path(crumb.route, crumb.routeParameters) %}
+                <li>
+                    <a href="{{ crumbPath }}" title="{{ crumbText }}">{{ crumbText }}</a>
+                </li>
+            {% endif %}
+        {% endfor %}
+    </ul>
 {% endif %}


### PR DESCRIPTION
I have removed the anchor from the last crumb, this is not only better for SEO, but also you don't need to set parameters if needed so the crumb can be generated just using annotations
