### PR TITLE
Removed Twig class alias calls

### DIFF
--- a/Twig/BreadcrumbExtension.php
+++ b/Twig/BreadcrumbExtension.php
@@ -3,11 +3,14 @@
 namespace Thormeier\BreadcrumbBundle\Twig;
 
 use Thormeier\BreadcrumbBundle\Provider\BreadcrumbProviderInterface;
+use Twig\Environment;
+use Twig\Extension\AbstractExtension;
+use Twig\TwigFunction;
 
 /**
  * Twig extension for breadcrumbs: Render a given template
  */
-class BreadcrumbExtension extends \Twig_Extension
+class BreadcrumbExtension extends AbstractExtension
 {
     /**
      * @var BreadcrumbProviderInterface
@@ -36,7 +39,7 @@ class BreadcrumbExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction(
+            new TwigFunction(
                 'breadcrumbs',
                 array(
                     $this,
@@ -51,11 +54,11 @@ class BreadcrumbExtension extends \Twig_Extension
     }
 
     /**
-     * @param \Twig_Environment $twigEnvironment
+     * @param Environment $twigEnvironment
      *
      * @return string
      */
-    public function renderBreadcrumbs(\Twig_Environment $twigEnvironment)
+    public function renderBreadcrumbs(Environment $twigEnvironment)
     {
         return $twigEnvironment->render($this->template, array(
             'breadcrumbs' => $this->breadcrumbProvider->getBreadcrumbs()->getAll()


### PR DESCRIPTION
Hello, in this [commit](https://github.com/twigphp/Twig/commit/273b666a7147afcbb219fb2b7bb4860bb934ac31#diff-baea780c28ff35525d36e8073aaa8d5a) the Twig developer team have removed the class aliases functions.

These changes are necessary to allow Twig 3.0 version.

Thanks